### PR TITLE
use the full strings file path as header and language key

### DIFF
--- a/lib/strings2csv/converter.rb
+++ b/lib/strings2csv/converter.rb
@@ -16,10 +16,11 @@ module Strings2CSV
     end
 
     def default_headers
-      headers = ['Variables']
+      headers = ["Variables"]
       @filenames.each do |fname|
-        headers << basename(fname)
+        headers << fname
       end
+      headers
     end
 
 
@@ -53,7 +54,7 @@ module Strings2CSV
       lang_order = []
 
       @filenames.each do |fname|
-        header = basename(fname)
+        header = fname
         strings[header] = load_strings(fname)
         lang_order << header
         keys ||= strings[header].keys


### PR DESCRIPTION
fixes problems with en.lproj/Localizable.strings de.lproj/Localizable.strings kind of collisions
