### PR TITLE
Fix "no implicit conversion of Array into String" error when installing gem.

### DIFF
--- a/csv2strings.gemspec
+++ b/csv2strings.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_path    = ['lib']
+  s.require_path  = 'lib'
 end


### PR DESCRIPTION
This should take care of #23.
