### PR TITLE
Replace hyphens with underscores for .babelish options

### DIFF
--- a/.babelish.sample
+++ b/.babelish.sample
@@ -19,13 +19,13 @@ langs:                             # Languages to convert. i.e. English:en
 
 ## optional
 # fetch: true                        # set to true to get file(filename) from google drive
-# excluded-states: ["Images", "Xib"] # Exclude rows with given state
-# state-column: 3                    # Position of column for state if any
-# keys-column: 0                     # Position of column for keys
-# default-lang: "English"            # Default language to use for empty values if any
-# output-dir: "resources/"         # Path of output files
-# output-file: "myOnlyFile.strings"  # --IGNORED-- Path of a single output file. Overrides 'output_dir'
-# output-basenames:
+# excluded_states: ["Images", "Xib"] # Exclude rows with given state
+# state_column: 3                    # Position of column for state if any
+# keys_column: 0                     # Position of column for keys
+# default_lang: "English"            # Default language to use for empty values if any
+# output_dir: "resources/"         # Path of output files
+# output_file: "myOnlyFile.strings"  # --IGNORED-- Path of a single output file. Overrides 'output_dir'
+# output_basenames:
 #   - Localizable
 #   - info
 # ignore_lang_path: true            # does not care about lang component path. i.e: en.lproj/


### PR DESCRIPTION
I noticed that "output-dir" wasn't working for me in my .babelish file but "output_dir" was.  I then saw issue netbe/Babelish#36 which mentioned this.

I've replaced all hyphens in the sample babelish file with underscores.
