### PR TITLE
Fixed issue regarding quotes in android xml files

### DIFF
--- a/lib/babelish/csv2android.rb
+++ b/lib/babelish/csv2android.rb
@@ -18,7 +18,7 @@ module Babelish
 
     def process_value(row_value, default_value)
       value = super(row_value, default_value)
-      # if the value beginns and ends with a quote we must leave them unescapted
+      # if the value begins and ends with a quote we must leave them unescapted
       if value.size > 4 && value[0,2] == "\\\"" && value[value.size - 2, value.size] == "\\\""
         value[0,2] = "\""
         value[value.size - 2, value.size] = "\""

--- a/lib/babelish/csv2android.rb
+++ b/lib/babelish/csv2android.rb
@@ -16,6 +16,16 @@ module Babelish
       return filepath ? [filepath] : []
     end
 
+    def process_value(row_value, default_value)
+      value = super(row_value, default_value)
+      # if the value beginns and ends with a quote we must leave them unescapted
+      if value.size > 4 && value[0,2] == "\\\"" && value[value.size - 2, value.size] == "\\\""
+        value[0,2] = "\""
+        value[value.size - 2, value.size] = "\""
+      end
+      return value.to_utf8
+    end
+
     def get_row_format(row_key, row_value, comment = nil, indentation = 0)
         return "\t<string name=\"#{row_key}\">#{row_value}</string>\n"
     end

--- a/test/babelish/test_csv2android.rb
+++ b/test/babelish/test_csv2android.rb
@@ -11,6 +11,17 @@ class TestCSV2Android < Test::Unit::TestCase
     system("rm -rf ./values-en")
   end
 
+  def test_converting_csv_with_special_chars
+    csv_file = "test/data/android_special_chars.csv"
+    converter = Babelish::CSV2Android.new(csv_file, 'german' => "de")
+    converter.convert
+    assert File.exists?("values-de/strings.xml"), "the ouptut file does not exist"
+    assert FileUtils.compare_file("values-de/strings.xml", "test/data/android_special_chars_test_result.xml")
+
+    #clean up
+    system("rm -rf ./values-de")
+  end
+
   def test_converting_csv_to_dotstrings_one_output_option
     csv_file = "test/data/test_data.csv"
     single_file = 'myApp.xml'

--- a/test/data/android_special_chars.csv
+++ b/test/data/android_special_chars.csv
@@ -1,0 +1,8 @@
+variables,german
+good_example_1,This\'ll work
+good_example_2,"This is a \""good string\""."
+good_example_3,"""This'll also work"""
+welcome_messages_1,"Hello, %1$s! You have %2$d new messages."
+welcome_messages_2,"Hello, %1$s! You have &lt;b&gt;%2$d new messages&lt;/b&gt;."
+ANOTHER_STRING,"text <b>with</b> html and \' special # chars ` ´ !""§$%/()==?{[]}"
+title,"Title of &lt;a href=""asd""&gt;File&lt;/a&gt;"

--- a/test/data/android_special_chars_test_result.xml
+++ b/test/data/android_special_chars_test_result.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+	<string name="good_example_1">This\'ll work</string>
+	<string name="good_example_2">This is a \"good string\".</string>
+	<string name="good_example_3">"This'll also work"</string>
+	<string name="welcome_messages_1">Hello, %1$s! You have %2$d new messages.</string>
+	<string name="welcome_messages_2">Hello, %1$s! You have &lt;b&gt;%2$d new messages&lt;/b&gt;.</string>
+	<string name="ANOTHER_STRING">text <b>with</b> html and \' special # chars ` ´ !\"§$%/()==?{[]}</string>
+	<string name="title">Title of &lt;a href=\"asd\"&gt;File&lt;/a&gt;</string>
+</resources>


### PR DESCRIPTION
After I check some of the possiblities of Android xml files I realized, that it's possible to create an entry which starts and ends with a quote.
If you do that it's no longer necessary to escape single quotes in between the quotes.
To fix that I overwrote the process_value method in the csv2android class and handle the quotes correctly.
I created an unittest to verify that functionality.