### PR TITLE
Do not convert if the localized string is empty

### DIFF
--- a/lib/babelish/csv2strings.rb
+++ b/lib/babelish/csv2strings.rb
@@ -16,8 +16,12 @@ module Babelish
     end
 
     def get_row_format(row_key, row_value, comment = nil, indentation = 0)
-      entry = comment.to_s.empty? ? "" : "\n/* #{comment} */\n" 
-      entry + "\"#{row_key}\"" + " " * indentation + " = \"#{row_value}\";\n"
+      if row_value == ""
+        entry = ""
+      else
+        entry = comment.to_s.empty? ? "" : "\n/* #{comment} */\n" 
+        entry + "\"#{row_key}\"" + " " * indentation + " = \"#{row_value}\";\n"
+      end
     end
 
     def extension


### PR DESCRIPTION
Instead of putting an empty string, leaving it out and iOS will automaticallly
choose the closest available localizable string.