### PR TITLE
Better file not exists error handling

### DIFF
--- a/lib/babelish/commandline.rb
+++ b/lib/babelish/commandline.rb
@@ -54,7 +54,11 @@ class Commandline < Thor
     method_option :headers, :type => :array, :aliases => "-h", :desc => "override headers of columns, default is name of input files and 'Variables' for reference"
     method_option :dryrun, :type => :boolean, :aliases => "-n", :desc => "prints out content of hash without writing file"
     define_method("#{klass[:name].downcase}") do
-      base2csv(klass[:name])
+      begin
+        base2csv(klass[:name])
+      rescue Errno::ENOENT => e
+        warn e.message
+      end
     end
   end
 

--- a/test/babelish/test_commandline.rb
+++ b/test/babelish/test_commandline.rb
@@ -78,6 +78,22 @@ class TestCommandLine < Test::Unit::TestCase
     system("rm -f .babelish")
   end
 
+  def test_base2csv_with_config_with_non_existent_filenames_fails
+    options = {:filenames => ['foo']}
+    config_file = File.new(".babelish", "w")
+    config_file.write options.to_yaml
+    config_file.close
+
+    _, stderr = capture_output do
+      Commandline.new.strings2csv
+    end
+    assert_match(/No such file or directory/, stderr)
+    assert_match(/foo/, stderr)
+
+    # clean up
+    system("rm -f .babelish")
+  end
+
   def test_csv_download_without_gd_filename_fails
     options = {}
     config_file = File.new(".babelish", "w")


### PR DESCRIPTION
This change makes the application to fail with a better error message when trying to open a non-existent file.

**Behavior before change**
```bash
$ bin/babelish android2csv --filenames=/tmp/android.xml --csv-filename=/tmp/android_run2.csv --headers=Vars German
/oss/Babelish/lib/babelish/android2csv.rb:11:in `initialize': No such file or directory @ rb_sysopen - /tmp/android.xml (Errno::ENOENT)
	from /oss/Babelish/lib/babelish/android2csv.rb:11:in `open'
	from /oss/Babelish/lib/babelish/android2csv.rb:11:in `load_strings'
	from /oss/Babelish/lib/babelish/base2csv.rb:31:in `block in convert'
	from /oss/Babelish/lib/babelish/base2csv.rb:29:in `each'
	from /oss/Babelish/lib/babelish/base2csv.rb:29:in `convert'
	from /oss/Babelish/lib/babelish/commandline.rb:170:in `base2csv'
	from /oss/Babelish/lib/babelish/commandline.rb:58:in `block (2 levels) in <class:Commandline>'
	from /.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from bin/babelish:6:in `<main>'
```

**Behavior after change**
```bash
$ bin/babelish android2csv --filenames=/tmp/android.xml --csv-filename=/tmp/android_run2.csv --headers=Vars German
No such file or directory @ rb_sysopen - /tmp/android.xml
```

This enhancement should resolve #75 