### PR TITLE
Implemented having comments in CSV

### DIFF
--- a/lib/babelish/android2csv.rb
+++ b/lib/babelish/android2csv.rb
@@ -6,22 +6,40 @@ module Babelish
       super(args)
     end
 
+    def parse_comment_line(line)
+      line.strip!
+      if line[0] != ?# && line[0] != ?=
+        m = line.match(/^\/\*(.*)\*\/\s*$/)
+        return m[1].strip! unless m.nil?
+      end
+    end
+
     def load_strings(strings_filename)
       strings = {}
+      comments = {}
       xml_file = File.open(strings_filename)
 
       parser = Nokogiri::XML(xml_file) do |config|
         config.strict.noent
       end
-      parser.xpath("//string").each do |node|
+
+      previous_comment = nil
+      parser.xpath("//resources").children.each do |node|
         if !node.nil? && !node["name"].nil?
           strings.merge!(node["name"] => node.inner_html)
+          comments[node["name"]] = previous_comment if previous_comment
+          previous_comment = nil
+        end
+        if node.comment?
+          comment = node.content
+          parsed_comment = parse_comment_line(comment)
+          previous_comment = parsed_comment || comment
         end
       end
 
       xml_file.close
 
-      [strings, {}]
+      [strings, comments]
     end
 
   end

--- a/test/babelish/test_android2csv.rb
+++ b/test/babelish/test_android2csv.rb
@@ -27,6 +27,14 @@ class TestAndroid2CSV < Test::Unit::TestCase
     assert_equal filenames, converter.filenames
   end
 
+  def test_load_strings_with_comments
+    expected_output = [{"app_name" => "android2csv", "action_greetings" => "Hello", "ANOTHER_STRING" => "testEN", "empty" => ""}, 
+      {"app_name" => "This is the app name", "action_greetings" => "This is a greeting", 
+        "ANOTHER_STRING" => "This is another string", "empty" => "This is an empty string"}]
+    output = Babelish::Android2CSV.new.load_strings "test/data/android-comments.xml"
+    assert_equal expected_output, output
+  end
+
   def test_initialize_with_default_values
     converter = Babelish::Android2CSV.new
     assert_not_nil converter.csv_filename

--- a/test/data/android-comments.xml
+++ b/test/data/android-comments.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+	<!-- This is the app name -->
+    <string name="app_name">android2csv</string>
+    <!-- This is a greeting -->
+    <string name="action_greetings">Hello</string>
+    <!-- This is another string -->
+    <string name="ANOTHER_STRING">testEN</string>
+    <!-- This is an empty string -->
+    <string name="empty"></string>
+
+</resources>


### PR DESCRIPTION
Android XML load strings does not load comments, whereas iOS Strings loads comments. Merely trying to mirror both platform strings conversion. 