### PR TITLE
Update google_drive dependency

### DIFF
--- a/babelish.gemspec
+++ b/babelish.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "thor"
 
-  s.add_dependency "google_drive", "~> 1.0.1"
+  s.add_dependency "google_drive", "~> 2.1.7"
   s.add_dependency "nokogiri"
   # google_drive dependency to ask for mail and password
   s.add_dependency "highline"


### PR DESCRIPTION
The old verison of the `google_drive` gem caused an error `cannot load such file -- google/api_client` when using this with `fastlane`.