### PR TITLE
Feature/fix cdata

### DIFF
--- a/lib/babelish/android2csv.rb
+++ b/lib/babelish/android2csv.rb
@@ -15,7 +15,10 @@ module Babelish
       end
       parser.xpath("//string").each do |node|
         if !node.nil? && !node["name"].nil?
-          strings.merge!(node["name"] => node.inner_html)
+          if node.cdata?
+            strings.merge!(node["name"] => '<![CDATA[' + node.inner_html + ']]>')
+          else
+            strings.merge!(node["name"] => node.inner_html)
         end
       end
 

--- a/test/babelish/test_android2csv.rb
+++ b/test/babelish/test_android2csv.rb
@@ -50,4 +50,24 @@ class TestAndroid2CSV < Test::Unit::TestCase
     # clean up
     system("rm -rf ./" + csv_filename)
   end
+
+  def test_cdata_are_not_removed
+    csv_filename = "./test.csv"
+    filename = "test/data/android_cdata.xml"
+    headers = %w{variables german}
+
+    expected_output = [["html"], {filename => {"html" => "<![CDATA[<p>Text<p>]]>"}}]
+    converter = Babelish::Android2CSV.new(
+      :csv_filename => csv_filename,
+      :headers => headers,
+      :filenames => [filename])
+
+    output = converter.convert(false)
+
+    assert File.exist?(converter.csv_filename)
+    assert_equal expected_output, output
+
+    # clean up
+    system("rm -rf ./" + csv_filename)
+  end
 end

--- a/test/data/android_cdata.xml
+++ b/test/data/android_cdata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+<string name="html"><![CDATA[<p>Text<p>]]></string>
+</resources>


### PR DESCRIPTION
Hi, 

Try use following method as a workaround to fix #73  (as a newbie of ruby...)

http://www.rubydoc.info/github/sparklemotion/nokogiri/Nokogiri/XML/Node#cdata%3F-instance_method
https://github.com/sparklemotion/nokogiri/blob/master/lib/nokogiri/xml/node.rb#L454

Append  the test you've written before.

Please take a look~ 

--

BTW I escape the string with CDATA to deal with #73 's problem for now 

Turn

`<string name="cdata"><![CDATA[Line number 1.<br />Line number 2.]]></string>`

Into

`<string name="cdata">Line number 1.&lt;br /&gt;Line number 2.</string>`

But it's kind of exhausted for me or my coworker to edit all our strings