### PR TITLE
Update google_drive gem version

### DIFF
--- a/babelish.gemspec
+++ b/babelish.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "thor"
 
-  s.add_dependency "google_drive", "~> 3.0.3"
+  s.add_dependency "google_drive", "~> 3.0.4"
   s.add_dependency "nokogiri"
   # google_drive dependency to ask for mail and password
   s.add_dependency "highline"


### PR DESCRIPTION
`fastlane 2.147.0` and `babelish 0.6.3` are not compatible because of some dependencies.

```
gem 'babelish', '0.6.3'
gem 'fastlane', '2.147.0'
```

Here is the error.

```
Bundler could not find compatible versions for gem "google-api-client":
  In snapshot (Gemfile.lock):
    google-api-client (= 0.36.4)

  In Gemfile:
    fastlane (= 2.148.0) was resolved to 2.148.0, which depends on
      google-api-client (>= 0.37.0, < 0.39.0)

    babelish (= 0.6.3) was resolved to 0.6.3, which depends on
      google_drive (~> 3.0.3) was resolved to 3.0.4, which depends on
        google-api-client (>= 0.11.0, < 0.37.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

This PR tries to fix this issue.

Thanks