### PR TITLE
docker repository names must be lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Requires Ruby 2.1.0 or above.
 
 Or download [Latest Release](https://github.com/netbe/Babelish/releases/latest).
 
-Or via docker: `docker run netbe/Babelish babelish help`
+Or via docker: `docker run netbe/babelish babelish help`
 
 # Usage
 


### PR DESCRIPTION
docker: invalid reference format: repository name must be lowercase.